### PR TITLE
refactor: upgrade gradle to 6.5

### DIFF
--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -23,7 +23,7 @@ object Versions {
 }
 
 object BuildPluginsVersion {
-    const val AGP = "3.6.3"
+    const val AGP = "4.0.0"
     const val DETEKT = "1.8.0"
     const val KOTLIN = "1.3.72"
     const val KTLINT = "9.2.1"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## 🚀 Description
Upgrade gradle from 6.3 to 6.5

## 📄 Motivation and Context
For the sake of keeping all dependencies up-to-date

## ✅ Checklist
- [x] My code follows the code style of this project.
- [x] If my change requires a change to the documentation, I have updated the documentation accordingly.
- [x] I ran this code locally.
